### PR TITLE
Fix one letter local keys support

### DIFF
--- a/NSManagedObject-HYPPropertyMapper.podspec
+++ b/NSManagedObject-HYPPropertyMapper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "NSManagedObject-HYPPropertyMapper"
-  s.version = "1.6"
+  s.version = "1.7"
   s.summary = "Mapping your Core Data objects with your JSON providing backend has never been this easy"
   s.description = <<-DESC
                    * Mapping your Core Data objects with your JSON providing backend has never been this easy

--- a/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
+++ b/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
@@ -92,12 +92,12 @@
 
     XCTAssertEqualObjects(remoteKey, [localKey remoteString]);
 
-    localKey = @"ID";
+    localKey = @"id";
     remoteKey = @"id";
 
     XCTAssertEqualObjects(remoteKey, [localKey remoteString]);
 
-    localKey = @"PDF";
+    localKey = @"pdf";
     remoteKey = @"pdf";
 
     XCTAssertEqualObjects(remoteKey, [localKey remoteString]);
@@ -126,12 +126,12 @@
     XCTAssertEqualObjects(localKey, [remoteKey localString]);
 
     remoteKey = @"id";
-    localKey = @"ID";
+    localKey = @"id";
 
     XCTAssertEqualObjects(localKey, [remoteKey localString]);
 
     remoteKey = @"pdf";
-    localKey = @"PDF";
+    localKey = @"pdf";
 
     XCTAssertEqualObjects(localKey, [remoteKey localString]);
 

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -22,7 +22,7 @@
 
     BOOL remoteStringIsAnAcronym = ([[NSString acronyms] containsObject:[processedString lowercaseString]]);
 
-    return (remoteStringIsAnAcronym) ? processedString : [processedString lowerCaseFirstLetter];
+    return (remoteStringIsAnAcronym) ? [processedString lowercaseString] : [processedString lowerCaseFirstLetter];
 }
 
 - (NSString *)lowerCaseFirstLetter


### PR DESCRIPTION
CoreData doesn’t allow you to make fields that start with an uppercase
