### PR TITLE
Fix: Safety and remote string

### DIFF
--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -303,11 +303,17 @@
             BOOL isToOneRelationship = (![relationshipValue isKindOfClass:[NSSet class]]);
             if (isToOneRelationship) continue;
 
-            NSSet *nonSortedRelationships = [self valueForKey:relationshipName];
 
-            NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:localKey ascending:YES];
-            NSArray *sortDescriptors = [NSArray arrayWithObject:sortDescriptor];
-            NSArray *relationships = [nonSortedRelationships sortedArrayUsingDescriptors:sortDescriptors];
+            NSArray *relationships;
+            if ([self.entity propertiesByName][localKey]) {
+                NSSet *nonSortedRelationships = [self valueForKey:relationshipName];
+
+                NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:localKey ascending:YES];
+                NSArray *sortDescriptors = [NSArray arrayWithObject:sortDescriptor];
+                relationships = [nonSortedRelationships sortedArrayUsingDescriptors:sortDescriptors];
+            } else {
+                relationships = [[self valueForKey:relationshipName] allObjects];
+            }
 
             NSMutableArray *relations = [NSMutableArray new];
 

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -312,10 +312,8 @@
             BOOL localKeyExists = (properties[localKey] != nil);
             if (localKeyExists) {
                 NSSet *nonSortedRelationships = [self valueForKey:relationshipName];
-
-                NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:localKey ascending:YES];
-                NSArray *sortDescriptors = [NSArray arrayWithObject:sortDescriptor];
-                relationships = [nonSortedRelationships sortedArrayUsingDescriptors:sortDescriptors];
+                NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:localKey ascending:YES];
+                relationships = [nonSortedRelationships sortedArrayUsingDescriptors:@[sortDescriptor]];
             } else {
                 relationships = [[self valueForKey:relationshipName] allObjects];
             }

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -305,7 +305,12 @@
 
 
             NSArray *relationships;
-            if ([self.entity propertiesByName][localKey]) {
+
+            NSEntityDescription *destinationEntity = [propertyDescription destinationEntity];
+            NSDictionary *properties = [destinationEntity propertiesByName];
+
+            BOOL localKeyExists = (properties[localKey] != nil);
+            if (localKeyExists) {
                 NSSet *nonSortedRelationships = [self valueForKey:relationshipName];
 
                 NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:localKey ascending:YES];

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -332,7 +332,7 @@
 
                         if (flatten) {
                             NSString *flattenKey = [NSString stringWithFormat:@"%@[%lu].%@", relationshipName, (unsigned long)relationIndex, key];
-                            mutableDictionary[flattenKey] = value;
+                            if (value) mutableDictionary[flattenKey] = value;
                         } else {
                             NSMutableDictionary *dictionary;
 
@@ -341,7 +341,8 @@
 
                             if (!dictionary) dictionary = [NSMutableDictionary new];
 
-                            dictionary[key] = value;
+                            if (value) dictionary[key] = value;
+
                             relations[relationIndex] = dictionary;
                         }
                     }

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -331,7 +331,7 @@
                         NSString *key = attributeIsKey ? @"id" : [attribute hyp_remoteString];
 
                         if (flatten) {
-                            NSString *flattenKey = [NSString stringWithFormat:@"%@[%lu].%@", relationshipName, (unsigned long)relationIndex, key];
+                            NSString *flattenKey = [NSString stringWithFormat:@"%@[%lu].%@", [relationshipName hyp_remoteString], (unsigned long)relationIndex, key];
                             if (value) mutableDictionary[flattenKey] = value;
                         } else {
                             NSMutableDictionary *dictionary;


### PR DESCRIPTION
Basically this is a workaround and some dictionary safety.

The workaround is [here](https://github.com/hyperoslo/NSManagedObject-HYPPropertyMapper/commit/b6fa81e25e60086fdfa0a92c77165937344f3f78).

If the model doesn't contain the primary key, lets say `noteID` for an entity `Note`. Then the app will crash. That's why we are checking for the existence of this key before sorting the list of elements by primary key.

The reason why this happens is because in another app we have an entity for example `Car`, but it's primary key it's not `carID`, but `carUUID` for example.

The real solution would be to support custom mappings. For example in your model graph (in user info), you should be able to say `carID` maps to `carUUID`.
