### PR TITLE
Improve: Relationship dictionary representation

### DIFF
--- a/NSManagedObject-HYPPropertyMapper.podspec
+++ b/NSManagedObject-HYPPropertyMapper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "NSManagedObject-HYPPropertyMapper"
-  s.version = "2.3.3"
+  s.version = "2.4"
   s.summary = "Mapping your Core Data objects with your JSON providing backend has never been this easy"
   s.description = <<-DESC
                    * Mapping your Core Data objects with your JSON providing backend has never been this easy

--- a/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
+++ b/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
@@ -177,11 +177,15 @@
     NSArray *notes = [dictionary valueForKey:@"notes"];
     XCTAssertTrue(notes.count == 3);
 
-    NSDictionary *noteDictionary = [notes firstObject];
+    NSDictionary *noteContainerDictionary = [notes firstObject];
+    NSDictionary *noteDictionary = [noteContainerDictionary valueForKey:@"0"];
+    XCTAssertNotNil(noteDictionary);
+
     XCTAssertEqualObjects([noteDictionary valueForKey:@"id"], @1);
     XCTAssertEqualObjects([noteDictionary valueForKey:@"text"], @"This is the text for the note 1");
 
-    noteDictionary = [notes lastObject];
+    noteContainerDictionary = [notes firstObject];
+    noteDictionary = [noteContainerDictionary valueForKey:@"1"];
     XCTAssertEqualObjects([noteDictionary valueForKey:@"id"], @14);
     XCTAssertEqualObjects([noteDictionary valueForKey:@"text"], @"This is the text for the note 14");
 }

--- a/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
+++ b/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
@@ -184,8 +184,8 @@
     XCTAssertEqualObjects([noteDictionary valueForKey:@"id"], @1);
     XCTAssertEqualObjects([noteDictionary valueForKey:@"text"], @"This is the text for the note 1");
 
-    noteContainerDictionary = [notes firstObject];
-    noteDictionary = [noteContainerDictionary valueForKey:@"1"];
+    noteContainerDictionary = [notes lastObject];
+    noteDictionary = [noteContainerDictionary valueForKey:@"2"];
     XCTAssertEqualObjects([noteDictionary valueForKey:@"id"], @14);
     XCTAssertEqualObjects([noteDictionary valueForKey:@"text"], @"This is the text for the note 14");
 }

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -200,16 +200,27 @@
                             NSString *flattenKey = [NSString stringWithFormat:@"%@[%lu].%@", [relationshipName hyp_remoteString], (unsigned long)relationIndex, key];
                             if (value) mutableDictionary[flattenKey] = value;
                         } else {
-                            NSMutableDictionary *dictionary;
+                            NSMutableDictionary *containerDictionary;
 
                             BOOL relationIndexInBounds = (relations.count > relationIndex);
-                            if (relationIndexInBounds) dictionary = [relations[relationIndex] mutableCopy];
+                            if (relationIndexInBounds) containerDictionary = [relations[relationIndex] mutableCopy];
 
-                            if (!dictionary) dictionary = [NSMutableDictionary new];
+                            NSString *relationIndexString = [NSString stringWithFormat:@"%lu", (unsigned long)relationIndex];
+
+                            NSMutableDictionary *dictionary;
+
+                            if (containerDictionary) {
+                                dictionary = containerDictionary[relationIndexString];
+                            } else {
+                                containerDictionary = [NSMutableDictionary new];
+                                dictionary = [NSMutableDictionary new];
+                            }
 
                             if (value) dictionary[key] = value;
 
-                            relations[relationIndex] = dictionary;
+                            containerDictionary[relationIndexString] = dictionary;
+
+                            relations[relationIndex] = containerDictionary;
                         }
                     }
                 }


### PR DESCRIPTION
### Convert

``` objc
NSDictionary *dictionary = [user hyp_dictionary];
```
### From

``` json
"notes": [
  {
     "id": 1,
     "text": "This is the text for the note 1"
  },
  {
     "id": 7,
     "text": "This is the text for the note 7"
  },
  {
     "id": 14,
     "text": "This is the text for the note 14"
  }
];
```
### To

``` json
"notes": [
  {
    "0": {
      "id": 1,
      "text": "This is the text for the note 1"
    },
    "1": {
      "id": 7,
      "text": "This is the text for the note 7"
    },
    "2": {
      "id": 14,
      "text": "This is the text for the note 14"
    }
  }
]
```
