### PR TITLE
Add support for "accepts_nested_attributes_for"

### DIFF
--- a/NSManagedObject-HYPPropertyMapper.podspec
+++ b/NSManagedObject-HYPPropertyMapper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "NSManagedObject-HYPPropertyMapper"
-  s.version = "2.4.2"
+  s.version = "2.4.3"
   s.summary = "Mapping your Core Data objects with your JSON providing backend has never been this easy"
   s.description = <<-DESC
                    * Mapping your Core Data objects with your JSON providing backend has never been this easy

--- a/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
+++ b/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
@@ -171,10 +171,10 @@
 {
     NSDictionary *dictionary = [self.testUser hyp_dictionary];
 
-    XCTAssertNotNil([dictionary valueForKey:@"notes"]);
-    XCTAssertTrue([[dictionary valueForKey:@"notes"] isKindOfClass:[NSDictionary class]]);
+    XCTAssertNotNil([dictionary valueForKey:@"notes_attributes"]);
+    XCTAssertTrue([[dictionary valueForKey:@"notes_attributes"] isKindOfClass:[NSDictionary class]]);
 
-    NSDictionary *notes = [dictionary valueForKey:@"notes"];
+    NSDictionary *notes = [dictionary valueForKey:@"notes_attributes"];
     XCTAssertTrue(notes.count == 3);
 
     NSDictionary *noteDictionary = [notes valueForKey:@"0"];

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ userValues {
 }
 ```
 
-It supports relationships too, for example for a user that has many notes:
+It supports relationships too, and we complain to the Rails rule `accepts_nested_attributes_for`, for example for a user that has many notes:
 
 ##### Normal
 ```json
 "first_name": "John",
 "last_name": "Hyperseed",
-"notes": [
+"notes_attributes": [
   {
     "0": {
       "id": 0,

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -212,7 +212,10 @@
                 }
                 relationIndex++;
             }
-            if (!flatten) [mutableDictionary setValue:relations forKey:[relationshipName hyp_remoteString]];
+            if (!flatten) {
+                NSString *nestedAttributesPrefix = [NSString stringWithFormat:@"%@_attributes", [relationshipName hyp_remoteString]];
+                [mutableDictionary setValue:relations forKey:nestedAttributesPrefix];
+            }
         }
     }
 


### PR DESCRIPTION
In Rails for nested forms is common to use the `accepts_nested_attributes_for` pattern, which adds the prefix `_attributes` to the relationship name.
