### PR TITLE
Skip empty models for hyp_dictionary

### DIFF
--- a/CoreData/PropertyMapperTestModel.xcdatamodeld/PropertyMapperTestModel.xcdatamodel/contents
+++ b/CoreData/PropertyMapperTestModel.xcdatamodeld/PropertyMapperTestModel.xcdatamodel/contents
@@ -6,7 +6,7 @@
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="company" inverseEntity="User" syncable="YES"/>
     </entity>
     <entity name="Note" representedClassName="Note" syncable="YES">
-        <attribute name="noteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="noteID" optional="YES" attributeType="Integer 32" syncable="YES"/>
         <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="notes" inverseEntity="User" syncable="YES"/>
     </entity>
@@ -28,8 +28,8 @@
         <relationship name="notes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Note" inverseName="user" inverseEntity="Note" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Note" positionX="-63" positionY="81" width="128" height="88"/>
-        <element name="User" positionX="-290" positionY="116" width="128" height="268"/>
         <element name="Company" positionX="25" positionY="279" width="128" height="88"/>
+        <element name="Note" positionX="-63" positionY="81" width="128" height="90"/>
+        <element name="User" positionX="-290" positionY="116" width="128" height="268"/>
     </elements>
 </model>

--- a/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
+++ b/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
@@ -61,6 +61,14 @@
     note = [self noteWithID:@7];
     note.user = user;
 
+    note = [NSEntityDescription insertNewObjectForEntityForName:@"Note"
+                                               inManagedObjectContext:self.managedObjectContext];
+    note.user = user;
+
+    note = [NSEntityDescription insertNewObjectForEntityForName:@"Note"
+                                         inManagedObjectContext:self.managedObjectContext];
+    note.user = user;
+
     Company *company = [self companyWithID:@1 andName:@"Facebook"];
     company.user = user;
 
@@ -179,7 +187,7 @@
     NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"id" ascending:YES];
     NSArray *sortedNotes = [[notes allValues] sortedArrayUsingDescriptors:@[sortDescriptor]];
 
-    XCTAssertTrue(sortedNotes.count == 3);
+    XCTAssertEqual(sortedNotes.count, 3);
 
     NSDictionary *noteDictionary = [sortedNotes firstObject];
     XCTAssertNotNil(noteDictionary);


### PR DESCRIPTION
When generating nested attributes, empty models (models without any of their attributes filled), should be skipped.
