### PR TITLE
Improve: use remoteID instead of entityID (userID/companyID)

### DIFF
--- a/CoreData/Company.h
+++ b/CoreData/Company.h
@@ -5,7 +5,7 @@
 
 @interface Company : NSManagedObject
 
-@property (nonatomic, retain) NSNumber * companyID;
+@property (nonatomic, retain) NSNumber * remoteID;
 @property (nonatomic, retain) NSString * name;
 @property (nonatomic, retain) User *user;
 

--- a/CoreData/Company.m
+++ b/CoreData/Company.m
@@ -3,7 +3,7 @@
 
 @implementation Company
 
-@dynamic companyID;
+@dynamic remoteID;
 @dynamic name;
 @dynamic user;
 

--- a/CoreData/Note.h
+++ b/CoreData/Note.h
@@ -5,7 +5,7 @@
 
 @interface Note : NSManagedObject
 
-@property (nonatomic, retain) NSNumber * noteID;
+@property (nonatomic, retain) NSNumber * remoteID;
 @property (nonatomic, retain) NSString * text;
 @property (nonatomic, retain) NSNumber * destroy;
 @property (nonatomic, retain) User *user;

--- a/CoreData/Note.m
+++ b/CoreData/Note.m
@@ -3,7 +3,7 @@
 
 @implementation Note
 
-@dynamic noteID;
+@dynamic remoteID;
 @dynamic text;
 @dynamic destroy;
 @dynamic user;

--- a/CoreData/PropertyMapperTestModel.xcdatamodeld/PropertyMapperTestModel.xcdatamodel/contents
+++ b/CoreData/PropertyMapperTestModel.xcdatamodeld/PropertyMapperTestModel.xcdatamodel/contents
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14C94b" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="6254" systemVersion="14C106a" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="Company" representedClassName="Company" syncable="YES">
-        <attribute name="companyID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="company" inverseEntity="User" syncable="YES"/>
     </entity>
     <entity name="Note" representedClassName="Note" syncable="YES">
         <attribute name="destroy" optional="YES" attributeType="Boolean" syncable="YES"/>
-        <attribute name="noteID" optional="YES" attributeType="Integer 32" syncable="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="Integer 32" syncable="YES"/>
         <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="notes" inverseEntity="User" syncable="YES"/>
     </entity>
@@ -21,16 +21,16 @@
         <attribute name="ignoredParameter" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="numberOfAttendes" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="updatedDate" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="userDescription" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="userID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="userType" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="company" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Company" inverseName="user" inverseEntity="Company" syncable="YES"/>
         <relationship name="notes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Note" inverseName="user" inverseEntity="Note" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Company" positionX="25" positionY="279" width="128" height="88"/>
+        <element name="Company" positionX="25" positionY="279" width="128" height="90"/>
         <element name="Note" positionX="-504" positionY="351" width="128" height="103"/>
-        <element name="User" positionX="-290" positionY="116" width="128" height="268"/>
+        <element name="User" positionX="-290" positionY="116" width="128" height="270"/>
     </elements>
 </model>

--- a/CoreData/User.h
+++ b/CoreData/User.h
@@ -16,7 +16,7 @@
 @property (nonatomic, retain) NSNumber * numberOfAttendes;
 @property (nonatomic, retain) NSDate * updatedDate;
 @property (nonatomic, retain) NSString * userDescription;
-@property (nonatomic, retain) NSNumber * userID;
+@property (nonatomic, retain) NSNumber * remoteID;
 @property (nonatomic, retain) NSString * userType;
 @property (nonatomic, retain) NSSet *notes;
 @property (nonatomic, retain) Company *company;

--- a/CoreData/User.m
+++ b/CoreData/User.m
@@ -15,7 +15,7 @@
 @dynamic numberOfAttendes;
 @dynamic updatedDate;
 @dynamic userDescription;
-@dynamic userID;
+@dynamic remoteID;
 @dynamic userType;
 @dynamic notes;
 @dynamic company;

--- a/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
+++ b/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
@@ -323,14 +323,13 @@
 - (void)testAcronyms
 {
     NSDictionary *values = @{
-                             @"user_id" : @100
+                             @"contract_id" : @100
                              };
 
     [self.testUser hyp_fillWithDictionary:values];
 
-    XCTAssertEqualObjects([self.testUser valueForKey:@"remoteID"], @100);
+    XCTAssertEqualObjects([self.testUser valueForKey:@"contractID"], @100);
 }
-
 
 - (void)testReservedWords
 {

--- a/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
+++ b/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
@@ -46,7 +46,7 @@
     user.firstName = @"John";
     user.lastName = @"Hyperseed";
     user.userDescription = @"John Description";
-    user.userID = @111;
+    user.remoteID = @111;
     user.userType = @"Manager";
     user.createdDate = [NSDate date];
     user.updatedDate = [NSDate date];
@@ -76,21 +76,21 @@
     return user;
 }
 
-- (Note *)noteWithID:(NSNumber *)noteID
+- (Note *)noteWithID:(NSNumber *)remoteID
 {
     Note *note = [NSEntityDescription insertNewObjectForEntityForName:@"Note"
                                                 inManagedObjectContext:self.managedObjectContext];
-    note.noteID = noteID;
-    note.text = [NSString stringWithFormat:@"This is the text for the note %@", noteID];
+    note.remoteID = remoteID;
+    note.text = [NSString stringWithFormat:@"This is the text for the note %@", remoteID];
 
     return note;
 }
 
-- (Company *)companyWithID:(NSNumber *)companyID andName:(NSString *)name
+- (Company *)companyWithID:(NSNumber *)remoteID andName:(NSString *)name
 {
     Company *company = [NSEntityDescription insertNewObjectForEntityForName:@"Company"
                                                      inManagedObjectContext:self.managedObjectContext];
-    company.companyID = companyID;
+    company.remoteID = remoteID;
     company.name = name;
 
     return company;
@@ -328,7 +328,7 @@
 
     [self.testUser hyp_fillWithDictionary:values];
 
-    XCTAssertEqualObjects([self.testUser valueForKey:@"userID"], @100);
+    XCTAssertEqualObjects([self.testUser valueForKey:@"remoteID"], @100);
 }
 
 
@@ -342,7 +342,7 @@
 
     [self.testUser hyp_fillWithDictionary:values];
 
-    XCTAssertEqualObjects([self.testUser valueForKey:@"userID"], @100);
+    XCTAssertEqualObjects([self.testUser valueForKey:@"remoteID"], @100);
 
     XCTAssertEqualObjects([self.testUser valueForKey:@"userDescription"], @"This is the description?");
 

--- a/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
+++ b/NSManagedObject-HYPPropertyMapperTests/NSManagedObject_HYPPropertyMapperTests.m
@@ -63,7 +63,7 @@
     note.user = user;
 
     note = [NSEntityDescription insertNewObjectForEntityForName:@"Note"
-                                               inManagedObjectContext:self.managedObjectContext];
+                                         inManagedObjectContext:self.managedObjectContext];
     note.user = user;
 
     note = [NSEntityDescription insertNewObjectForEntityForName:@"Note"
@@ -79,7 +79,7 @@
 - (Note *)noteWithID:(NSNumber *)remoteID
 {
     Note *note = [NSEntityDescription insertNewObjectForEntityForName:@"Note"
-                                                inManagedObjectContext:self.managedObjectContext];
+                                               inManagedObjectContext:self.managedObjectContext];
     note.remoteID = remoteID;
     note.text = [NSString stringWithFormat:@"This is the text for the note %@", remoteID];
 

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -64,7 +64,11 @@
 
         BOOL isReservedKey = ([[NSManagedObject reservedAttributes] containsObject:remoteKey]);
         if (isReservedKey) {
-            remoteKey = [self prefixedAttribute:remoteKey];
+            if ([remoteKey isEqualToString:@"id"]) {
+                remoteKey = @"remote_id";
+            } else {
+                remoteKey = [self prefixedAttribute:remoteKey];
+            }
         }
 
         id propertyDescription = [self propertyDescriptionForKey:remoteKey];
@@ -140,13 +144,16 @@
             if (nilOrNullValue) {
                 mutableDictionary[key] = [NSNull null];
             } else {
-                NSMutableString *key = [[[propertyDescription name] hyp_remoteString] mutableCopy];
                 BOOL isReservedKey = ([[self reservedKeys] containsObject:key]);
                 if (isReservedKey) {
-                    [key replaceOccurrencesOfString:[self remotePrefix]
-                                         withString:@""
-                                            options:NSCaseInsensitiveSearch
-                                              range:NSMakeRange(0, key.length)];
+                    if ([key isEqualToString:@"remote_id"]) {
+                        key = [@"id" mutableCopy];
+                    } else {
+                        [key replaceOccurrencesOfString:[self remotePrefix]
+                                             withString:@""
+                                                options:NSCaseInsensitiveSearch
+                                                  range:NSMakeRange(0, key.length)];
+                    }
                 }
                 mutableDictionary[key] = value;
             }
@@ -176,7 +183,7 @@
                         }
 
                         NSString *attribute = [propertyDescription name];
-                        NSString *localKey = [NSString stringWithFormat:@"%@ID", [relation.entity.name lowercaseString]];
+                        NSString *localKey = @"remoteID";
                         BOOL attributeIsKey = ([localKey isEqualToString:attribute]);
 
                         NSString *key;
@@ -227,6 +234,8 @@
     for (NSString *attribute in reservedAttributes) {
         [keys addObject:[self prefixedAttribute:attribute]];
     }
+
+    [keys addObject:@"remote_id"];
 
     return keys;
 }

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -58,34 +58,27 @@
 
 - (void)hyp_fillWithDictionary:(NSDictionary *)dictionary
 {
-    for (__strong NSString *remoteKey in dictionary) {
+    for (__strong NSString *key in dictionary) {
 
-        id value = [dictionary objectForKey:remoteKey];
+        id value = [dictionary objectForKey:key];
 
-        BOOL isReservedKey = ([[NSManagedObject reservedAttributes] containsObject:remoteKey]);
-        if (isReservedKey) {
-            if ([remoteKey isEqualToString:@"id"]) {
-                remoteKey = @"remote_id";
-            } else {
-                remoteKey = [self prefixedAttribute:remoteKey];
-            }
-        }
+        BOOL isReservedKey = ([[NSManagedObject reservedAttributes] containsObject:key]);
+        if (isReservedKey) key = [self prefixedAttribute:key];
 
-        id propertyDescription = [self propertyDescriptionForKey:remoteKey];
+        id propertyDescription = [self propertyDescriptionForKey:key];
         if (!propertyDescription) continue;
 
         NSString *localKey = [propertyDescription name];
 
-        if (value && ![value isKindOfClass:[NSNull class]]) {
-
+        BOOL valueExists = (value && ![value isKindOfClass:[NSNull class]]);
+        if (valueExists) {
             id processedValue = [self valueForPropertyDescription:propertyDescription
                                                  usingRemoteValue:value];
 
             BOOL valueHasChanged = (![[self valueForKey:localKey] isEqual:processedValue]);
             if (valueHasChanged) [self setValue:processedValue forKey:localKey];
-
-        } else {
-            if ([self valueForKey:localKey]) [self setValue:nil forKey:localKey];
+        } else if ([self valueForKey:localKey]) {
+            [self setValue:nil forKey:localKey];
         }
     }
 }
@@ -223,7 +216,15 @@
 
 - (NSString *)prefixedAttribute:(NSString *)attribute
 {
-    return [NSString stringWithFormat:@"%@%@", [self remotePrefix], attribute];
+    NSString *prefixedAttribute;
+
+    if ([attribute isEqualToString:@"id"]) {
+        prefixedAttribute = @"remote_id";
+    } else {
+        prefixedAttribute = [NSString stringWithFormat:@"%@%@", [self remotePrefix], attribute];
+    }
+
+    return prefixedAttribute;
 }
 
 - (NSArray *)reservedKeys


### PR DESCRIPTION
I've been thinking that having a `userID` for a `User` model is a lot of overhead. So moving to `remoteID` seems a better idea, the ideal think would be to just use `id` but that's a reserved key.

Also another good thing about `remoteID` is that you can play with the concept of having a `localID`, objects created locally that haven't been synced with the backend.

For example:

``` objc
User *user = [User new...];
user.userID = @100;
```

Will become:

``` objc
User *user = [User new...];
user.remoteID = @100;
```
