### PR TITLE
Feature: support date strings with no timestamp

### DIFF
--- a/Pod/Podfile
+++ b/Pod/Podfile
@@ -1,2 +1,1 @@
 pod 'NSString-HYPNetworking'
-pod 'NSDate-HYPString'

--- a/Pod/Podfile
+++ b/Pod/Podfile
@@ -1,1 +1,2 @@
 pod 'NSString-HYPNetworking'
+pod 'NSDate-HYPString'

--- a/Pod/Podfile.lock
+++ b/Pod/Podfile.lock
@@ -1,13 +1,10 @@
 PODS:
-  - NSDate-HYPString (0.2)
-  - NSString-HYPNetworking (0.3.1)
+  - NSString-HYPNetworking (0.3.2)
 
 DEPENDENCIES:
-  - NSDate-HYPString
   - NSString-HYPNetworking
 
 SPEC CHECKSUMS:
-  NSDate-HYPString: b87cf854edd44ec1e186b32526c601502180846d
-  NSString-HYPNetworking: 49ed5fd85aeb3159da40f8aabad787c4d13d17d7
+  NSString-HYPNetworking: f95766d4dc5693b45a0331ab8cf3a0b998f38cd7
 
 COCOAPODS: 0.36.4

--- a/Pod/Podfile.lock
+++ b/Pod/Podfile.lock
@@ -1,10 +1,13 @@
 PODS:
+  - NSDate-HYPString (0.2)
   - NSString-HYPNetworking (0.3.1)
 
 DEPENDENCIES:
+  - NSDate-HYPString
   - NSString-HYPNetworking
 
 SPEC CHECKSUMS:
+  NSDate-HYPString: b87cf854edd44ec1e186b32526c601502180846d
   NSString-HYPNetworking: 49ed5fd85aeb3159da40f8aabad787c4d13d17d7
 
 COCOAPODS: 0.36.4

--- a/Pod/Tests/Tests.m
+++ b/Pod/Tests/Tests.m
@@ -374,7 +374,7 @@
 - (void)testCreatedAt
 {
     NSDictionary *values = @{@"created_at" : @"2014-01-01T00:00:00+00:00",
-                             @"updated_at" : @"2014-01-02T00:00:00+00:00",
+                             @"updated_at" : @"2014-01-02",
                              @"number_of_attendes": @20};
 
     [self.testUser hyp_fillWithDictionary:values];

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -191,43 +191,43 @@ static NSString * const HYPPropertyMapperDateNoTimeStampFormat = @"YYYY-MM-DD";
     return foundPropertyDescription;
 }
 
-- (id)valueForPropertyDescription:(id)propertyDescription usingRemoteValue:(id)removeValue
+- (id)valueForPropertyDescription:(id)propertyDescription usingRemoteValue:(id)remoteValue
 {
     id value;
 
     NSAttributeDescription *attributeDescription = (NSAttributeDescription *)propertyDescription;
     Class attributedClass = NSClassFromString([attributeDescription attributeValueClassName]);
 
-    if ([removeValue isKindOfClass:attributedClass]) {
-        value = removeValue;
+    if ([remoteValue isKindOfClass:attributedClass]) {
+        value = remoteValue;
     }
 
-    BOOL stringValueAndNumberAttribute = ([removeValue isKindOfClass:[NSString class]] &&
+    BOOL stringValueAndNumberAttribute = ([remoteValue isKindOfClass:[NSString class]] &&
                                           attributedClass == [NSNumber class]);
 
-    BOOL numberValueAndStringAttribute = ([removeValue isKindOfClass:[NSNumber class]] &&
+    BOOL numberValueAndStringAttribute = ([remoteValue isKindOfClass:[NSNumber class]] &&
                                           attributedClass == [NSString class]);
 
-    BOOL stringValueAndDateAttribute   = ([removeValue isKindOfClass:[NSString class]] &&
+    BOOL stringValueAndDateAttribute   = ([remoteValue isKindOfClass:[NSString class]] &&
                                           attributedClass == [NSDate class]);
 
-    BOOL arrayOrDictionaryValueAndDataAttribute   = (([removeValue isKindOfClass:[NSArray class]] ||
-                                                      [removeValue isKindOfClass:[NSDictionary class]]) &&
+    BOOL arrayOrDictionaryValueAndDataAttribute   = (([remoteValue isKindOfClass:[NSArray class]] ||
+                                                      [remoteValue isKindOfClass:[NSDictionary class]]) &&
                                                      attributedClass == [NSData class]);
 
     if (stringValueAndNumberAttribute) {
         NSNumberFormatter *formatter = [NSNumberFormatter new];
         formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
-        value = [formatter numberFromString:removeValue];
+        value = [formatter numberFromString:remoteValue];
     } else if (numberValueAndStringAttribute) {
-        value = [NSString stringWithFormat:@"%@", removeValue];
+        value = [NSString stringWithFormat:@"%@", remoteValue];
     } else if (stringValueAndDateAttribute) {
-        if ([removeValue length] == [HYPPropertyMapperDateNoTimeStampFormat length]) {
-            removeValue = [NSString stringWithFormat:@"%@%@", removeValue, @"T00:00:00+00:00"];
+        if ([remoteValue length] == [HYPPropertyMapperDateNoTimeStampFormat length]) {
+            remoteValue = [NSString stringWithFormat:@"%@%@", remoteValue, @"T00:00:00+00:00"];
         }
-        value = [NSDate hyp_dateFromISO8601String:removeValue];
+        value = [NSDate hyp_dateFromISO8601String:remoteValue];
     } else if (arrayOrDictionaryValueAndDataAttribute) {
-        value = [NSKeyedArchiver archivedDataWithRootObject:removeValue];
+        value = [NSKeyedArchiver archivedDataWithRootObject:remoteValue];
     }
 
     return value;

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -9,6 +9,8 @@ static NSString * const HYPPropertyMapperKeyValue = @"value";
 static NSString * const HYPPropertyMapperNestedAttributesKey = @"attributes";
 static NSString * const HYPPropertyMapperDestroyKey = @"destroy";
 
+static NSString * const HYPPropertyMapperDateNoTimeStampFormat = @"YYYY-MM-DD";
+
 @interface NSDate (HYPISO8601)
 
 + (NSDate *)hyp_dateFromISO8601String:(NSString *)iso8601;
@@ -220,7 +222,7 @@ static NSString * const HYPPropertyMapperDestroyKey = @"destroy";
     } else if (numberValueAndStringAttribute) {
         value = [NSString stringWithFormat:@"%@", removeValue];
     } else if (stringValueAndDateAttribute) {
-        if ([removeValue length] == [@"2014-01-02" length]) {
+        if ([removeValue length] == [HYPPropertyMapperDateNoTimeStampFormat length]) {
             removeValue = [NSString stringWithFormat:@"%@%@", removeValue, @"T00:00:00+00:00"];
         }
         value = [NSDate hyp_dateFromISO8601String:removeValue];

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -9,7 +9,8 @@ static NSString * const HYPPropertyMapperKeyValue = @"value";
 static NSString * const HYPPropertyMapperNestedAttributesKey = @"attributes";
 static NSString * const HYPPropertyMapperDestroyKey = @"destroy";
 
-static NSString * const HYPPropertyMapperDateNoTimeStampFormat = @"YYYY-MM-DD";
+static NSString * const HYPPropertyMapperDateNoTimestampFormat = @"YYYY-MM-DD";
+static NSString * const HYPPropertyMapperTimestamp = @"T00:00:00+00:00";
 
 @interface NSDate (HYPISO8601)
 
@@ -222,9 +223,12 @@ static NSString * const HYPPropertyMapperDateNoTimeStampFormat = @"YYYY-MM-DD";
     } else if (numberValueAndStringAttribute) {
         value = [NSString stringWithFormat:@"%@", remoteValue];
     } else if (stringValueAndDateAttribute) {
-        if ([remoteValue length] == [HYPPropertyMapperDateNoTimeStampFormat length]) {
-            remoteValue = [NSString stringWithFormat:@"%@%@", remoteValue, @"T00:00:00+00:00"];
+        if ([remoteValue length] == [HYPPropertyMapperDateNoTimestampFormat length]) {
+            NSMutableString *mutableRemoteValue = [remoteValue mutableCopy];
+            [mutableRemoteValue appendString:HYPPropertyMapperTimestamp];
+            remoteValue = [mutableRemoteValue copy];
         }
+
         value = [NSDate hyp_dateFromISO8601String:remoteValue];
     } else if (arrayOrDictionaryValueAndDataAttribute) {
         value = [NSKeyedArchiver archivedDataWithRootObject:remoteValue];

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -220,6 +220,9 @@ static NSString * const HYPPropertyMapperDestroyKey = @"destroy";
     } else if (numberValueAndStringAttribute) {
         value = [NSString stringWithFormat:@"%@", removeValue];
     } else if (stringValueAndDateAttribute) {
+        if ([removeValue length] == [@"2014-01-02" length]) {
+            removeValue = [NSString stringWithFormat:@"%@%@", removeValue, @"T00:00:00+00:00"];
+        }
         value = [NSDate hyp_dateFromISO8601String:removeValue];
     } else if (arrayOrDictionaryValueAndDataAttribute) {
         value = [NSKeyedArchiver archivedDataWithRootObject:removeValue];


### PR DESCRIPTION
Add support for this:

``` json
{
  "created_at": "2014-01-01T00:00:00+00:00",
  "updated_at": "2014-01-02",
  "number_of_attendes": 20
}
```
