### PR TITLE
Optionally map relationships to nested attributes

### DIFF
--- a/Source/NSManagedObject+HYPPropertyMapper.h
+++ b/Source/NSManagedObject+HYPPropertyMapper.h
@@ -13,11 +13,15 @@ static NSString * const HYPPropertyMapperCustomRemoteKey = @"hyper.remoteKey";
 
 - (NSDictionary *)hyp_dictionary;
 
+- (NSDictionary *)hyp_dictionary:(BOOL)mapRelationshipsToNestedAttributes;
+
 /*! Creates a NSDictionary of values based on the NSManagedObject subclass that can be serialized by NSJSONSerialization. Includes relationships to other models.
  * \param dateFormatter - A custom date formatter that turns NSDate objects into NSString objects. Do not pass nil, instead use the 'hyp_dictionary' method
  * \return NSDictionary of values that can be serialized
  */
 
 - (NSDictionary *)hyp_dictionaryWithDateFormatter:(NSDateFormatter *)formatter;
+
+- (NSDictionary *)hyp_dictionaryWithDateFormatter:(NSDateFormatter *)formatter mappingRelationshipsToNestedAttributes:(BOOL)mapRelationshipsToNestedAttributes;
 
 @end

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -43,10 +43,18 @@ static NSString * const HYPPropertyMapperDestroyKey = @"destroy";
 }
 
 - (NSDictionary *)hyp_dictionary {
-    return [self hyp_dictionaryWithDateFormatter:[self defaultDateFormatter]];
+    return [self hyp_dictionaryWithDateFormatter:[self defaultDateFormatter] mappingRelationshipsToNestedAttributes:YES];
+}
+
+- (NSDictionary *)hyp_dictionary:(BOOL)mapRelationshipsToNestedAttributes {
+    return [self hyp_dictionaryWithDateFormatter:[self defaultDateFormatter] mappingRelationshipsToNestedAttributes:mapRelationshipsToNestedAttributes];
 }
 
 - (NSDictionary *)hyp_dictionaryWithDateFormatter:(NSDateFormatter *)formatter {
+    return [self hyp_dictionaryWithDateFormatter:formatter mappingRelationshipsToNestedAttributes:YES];
+}
+
+- (NSDictionary *)hyp_dictionaryWithDateFormatter:(NSDateFormatter *)formatter mappingRelationshipsToNestedAttributes:(BOOL)mapRelationshipsToNestedAttributes {
     NSMutableDictionary *managedObjectAttributes = [NSMutableDictionary new];
 
     for (id propertyDescription in self.entity.properties) {
@@ -65,7 +73,7 @@ static NSString * const HYPPropertyMapperDestroyKey = @"destroy";
             NSString *remoteKey = [self remoteKeyForAttributeDescription:attributeDescription];
             managedObjectAttributes[remoteKey] = value;
 
-        } else if ([propertyDescription isKindOfClass:[NSRelationshipDescription class]]) {
+        } else if (mapRelationshipsToNestedAttributes == YES && [propertyDescription isKindOfClass:[NSRelationshipDescription class]]) {
             NSString *relationshipName = [propertyDescription name];
 
             id relationships = [self valueForKey:relationshipName];


### PR DESCRIPTION
For "unusual" non Ruby on Rails usage mapping relationships to nested attributes should be optional.
