### PR TITLE
Improve check for decimal values

### DIFF
--- a/Tests/HYPDictionaryTests.m
+++ b/Tests/HYPDictionaryTests.m
@@ -131,8 +131,15 @@
     XCTAssertEqualObjects(resultDictionary[@"integer16"], @16);
     XCTAssertEqualObjects(resultDictionary[@"integer32"], @32);
     XCTAssertEqualObjects(resultDictionary[@"integer64"], @64);
+
     XCTAssertEqualObjects(resultDictionary[@"decimal_string"], [NSDecimalNumber decimalNumberWithString:@"12.2"]);
+    XCTAssertEqualObjects(NSStringFromClass([resultDictionary[@"decimal_string"] class]), NSStringFromClass([NSDecimalNumber class]));
+    XCTAssertNotEqualObjects(NSStringFromClass([resultDictionary[@"decimal_string"] class]), NSStringFromClass([NSNumber class]));
+
     XCTAssertEqualObjects(resultDictionary[@"decimal"], [NSDecimalNumber decimalNumberWithString:@"12.2"]);
+    XCTAssertEqualObjects(NSStringFromClass([resultDictionary[@"decimal"] class]), NSStringFromClass([NSDecimalNumber class]));
+    XCTAssertNotEqualObjects(NSStringFromClass([resultDictionary[@"decimal"] class]), NSStringFromClass([NSNumber class]));
+
     XCTAssertEqualObjects(resultDictionary[@"double_value_string"], @12.2);
     XCTAssertEqualObjects(resultDictionary[@"double_value"], @12.2);
     XCTAssertEqualWithAccuracy([resultDictionary[@"float_value_string"] longValue], [@12 longValue], 1.0);

--- a/Tests/HYPFillWithDictionaryTests.m
+++ b/Tests/HYPFillWithDictionaryTests.m
@@ -128,6 +128,7 @@
     XCTAssertEqualObjects(attributes.integer16, @16);
     XCTAssertEqualObjects(attributes.integer32, @32);
     XCTAssertEqualObjects(attributes.integer64, @64);
+
     XCTAssertEqualObjects(attributes.decimalString, [NSDecimalNumber decimalNumberWithString:@"12.2"]);
     XCTAssertEqualObjects(NSStringFromClass([attributes.decimalString class]), NSStringFromClass([NSDecimalNumber class]));
     XCTAssertNotEqualObjects(NSStringFromClass([attributes.decimalString class]), NSStringFromClass([NSNumber class]));

--- a/Tests/HYPFillWithDictionaryTests.m
+++ b/Tests/HYPFillWithDictionaryTests.m
@@ -129,7 +129,13 @@
     XCTAssertEqualObjects(attributes.integer32, @32);
     XCTAssertEqualObjects(attributes.integer64, @64);
     XCTAssertEqualObjects(attributes.decimalString, [NSDecimalNumber decimalNumberWithString:@"12.2"]);
+    XCTAssertEqualObjects(NSStringFromClass([attributes.decimalString class]), NSStringFromClass([NSDecimalNumber class]));
+    XCTAssertNotEqualObjects(NSStringFromClass([attributes.decimalString class]), NSStringFromClass([NSNumber class]));
+
     XCTAssertEqualObjects(attributes.decimal, [NSDecimalNumber decimalNumberWithString:@"12.2"]);
+    XCTAssertEqualObjects(NSStringFromClass([attributes.decimal class]), NSStringFromClass([NSDecimalNumber class]));
+    XCTAssertNotEqualObjects(NSStringFromClass([attributes.decimal class]), NSStringFromClass([NSNumber class]));
+
     XCTAssertEqualObjects(attributes.doubleValueString, @12.2);
     XCTAssertEqualObjects(attributes.doubleValue, @12.2);
     XCTAssertEqualWithAccuracy(attributes.floatValueString.longValue, [@12 longValue], 1.0);


### PR DESCRIPTION
Makes sure that the received decimals are NSDecimalNumber instead of NSNumber.
