### PR TITLE
Fix mapping of reserved attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ DerivedData
 
 # CocoaPods
 Pods
-*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.1
+osx_image: xcode7.3
 language: objective-c
 cache: cocoapods
 before_install: gem install xcpretty cocoapods obcd slather -N

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,20 @@
+PODS:
+  - DATAStack (4.2.1)
+  - NSManagedObject-HYPPropertyMapper (3.4.2):
+    - NSString-HYPNetworking (~> 0.4.0)
+  - NSString-HYPNetworking (0.4.0)
+
+DEPENDENCIES:
+  - DATAStack
+  - NSManagedObject-HYPPropertyMapper (from `.`)
+
+EXTERNAL SOURCES:
+  NSManagedObject-HYPPropertyMapper:
+    :path: "."
+
+SPEC CHECKSUMS:
+  DATAStack: 38009d8509307fca8c5bb26bca149e2e601fc369
+  NSManagedObject-HYPPropertyMapper: 9f3dd46e4265d7f6ba1ce0039ce1fc28524e9937
+  NSString-HYPNetworking: 24c3828eebde8a37cc16101a475934a56ac820c0
+
+COCOAPODS: 0.39.0

--- a/Source/NSManagedObject+HYPPropertyMapper.m
+++ b/Source/NSManagedObject+HYPPropertyMapper.m
@@ -15,11 +15,6 @@ static NSString * const HYPPropertyMapperNestedAttributesKey = @"attributes";
 
         id value = [dictionary objectForKey:key];
 
-        BOOL isReservedKey = ([[NSManagedObject reservedAttributes] containsObject:key]);
-        if (isReservedKey) {
-            key = [self prefixedAttribute:key];
-        }
-
         NSAttributeDescription *attributeDescription = [self attributeDescriptionForRemoteKey:key];
         if (attributeDescription) {
             NSString *localKey = attributeDescription.name;

--- a/Source/NSManagedObject+HYPPropertyMapperHelpers.m
+++ b/Source/NSManagedObject+HYPPropertyMapperHelpers.m
@@ -33,13 +33,21 @@
 
             NSDictionary *userInfo = [self.entity.propertiesByName[attributeDescription.name] userInfo];
             NSString *customRemoteKey = userInfo[HYPPropertyMapperCustomRemoteKey];
-            if (customRemoteKey.length > 0 && [customRemoteKey isEqualToString:remoteKey]) {
-                foundAttributeDescription = self.entity.propertiesByName[attributeDescription.name];
-            } else if ([attributeDescription.name isEqualToString:[remoteKey hyp_localString]]) {
+            BOOL currentAttributeHasTheSameRemoteKey = (customRemoteKey.length > 0 && [customRemoteKey isEqualToString:remoteKey]);
+            if (currentAttributeHasTheSameRemoteKey) {
                 foundAttributeDescription = attributeDescription;
+                *stop = YES;
             }
 
-            if (foundAttributeDescription) {
+            NSString *localKey = [remoteKey hyp_localString];
+            BOOL isReservedKey = ([[NSManagedObject reservedAttributes] containsObject:remoteKey]);
+            if (isReservedKey) {
+                NSString *prefixedRemoteKey = [self prefixedAttribute:remoteKey];
+                localKey = [prefixedRemoteKey hyp_localString];
+            }
+
+            if ([attributeDescription.name isEqualToString:localKey]) {
+                foundAttributeDescription = attributeDescription;
                 *stop = YES;
             }
         }

--- a/Tests/HYPDictionaryTests.m
+++ b/Tests/HYPDictionaryTests.m
@@ -105,7 +105,6 @@
 
 #pragma mark - hyp_dictionary
 
-
 - (void)testAllAttributes {
     NSDictionary *values = @{@"integer_string" : @"16",
                              @"integer16" : @16,
@@ -118,6 +117,7 @@
                              @"float_value_string" : @"12.2",
                              @"float_value" : @12.2,
                              @"string" : @"string",
+                             @"type" : @"custom",
                              @"boolean" : @YES,
                              @"binary_data" : @"Data",
                              @"transformable" : @"Ignore me, too"};
@@ -125,6 +125,7 @@
     DATAStack *dataStack = [self dataStack];
     Attributes *attributes = [self entityNamed:@"Attributes" inContext:dataStack.mainContext];
     [attributes hyp_fillWithDictionary:values];
+    XCTAssertEqualObjects(values[@"type"], attributes.attributeType);
 
     NSDictionary *resultDictionary = [attributes hyp_dictionary];
     XCTAssertEqualObjects(resultDictionary[@"integer_string"], @16);
@@ -149,6 +150,7 @@
     XCTAssertEqualObjects(resultDictionary[@"binary_data"], [NSKeyedArchiver archivedDataWithRootObject:@"Data"]);
     XCTAssertNil(resultDictionary[@"transformable"]);
     XCTAssertEqual(values.allKeys.count - 1, resultDictionary.allKeys.count);
+    XCTAssertEqualObjects(resultDictionary[@"type"], @"custom");
 }
 
 - (NSDictionary *)userDictionaryWithNoRelationships {

--- a/Tests/HYPDictionaryTests.m
+++ b/Tests/HYPDictionaryTests.m
@@ -61,6 +61,7 @@
     user.createdAt = self.testDate;
     user.updatedAt = self.testDate;
     user.numberOfAttendes = @30;
+    user.rawSigned = @"raw";
     user.hobbies = [NSKeyedArchiver archivedDataWithRootObject:@[@"Football",
                                                                  @"Soccer",
                                                                  @"Code",
@@ -179,6 +180,7 @@
     comparedDictionary[@"number_of_attendes"] = @30;
     comparedDictionary[@"type"] = @"Manager";
     comparedDictionary[@"updated_at"] = resultDateString;
+    comparedDictionary[@"signed"] = @"raw";
 
     return [comparedDictionary copy];
 }
@@ -226,6 +228,7 @@
                                                       storeType:DATAStackStoreTypeInMemory];
 
     User *user = [self entityNamed:@"User" inContext:dataStack.mainContext];
+    user.rawSigned = @"raw";
     user.age = @25;
     user.birthDate = self.testDate;
     user.contractID = @235;

--- a/Tests/HYPDictionaryTests.m
+++ b/Tests/HYPDictionaryTests.m
@@ -125,7 +125,7 @@
     DATAStack *dataStack = [self dataStack];
     Attributes *attributes = [self entityNamed:@"Attributes" inContext:dataStack.mainContext];
     [attributes hyp_fillWithDictionary:values];
-    XCTAssertEqualObjects(values[@"type"], attributes.attributeType);
+    XCTAssertEqualObjects(values[@"type"], attributes.attributesType);
 
     NSDictionary *resultDictionary = [attributes hyp_dictionary];
     XCTAssertEqualObjects(resultDictionary[@"integer_string"], @16);

--- a/Tests/HYPFillWithDictionaryTests.m
+++ b/Tests/HYPFillWithDictionaryTests.m
@@ -293,15 +293,12 @@
     NSDictionary *values = @{@"id": @100,
                              @"description": @"This is the description?",
                              @"type": @"user type"};
-
     DATAStack *dataStack = [self dataStack];
     User *user = [self userUsingDataStack:dataStack];
     [user hyp_fillWithDictionary:values];
 
     XCTAssertEqualObjects([user valueForKey:@"remoteID"], @100);
-
     XCTAssertEqualObjects([user valueForKey:@"userDescription"], @"This is the description?");
-
     XCTAssertEqualObjects([user valueForKey:@"userType"], @"user type");
 }
 
@@ -329,7 +326,8 @@
 
 - (void)testCustomRemoteKeys {
     NSDictionary *values = @{@"age_of_person" : @20,
-                             @"driver_identifier_str" : @"123"};
+                             @"driver_identifier_str" : @"123",
+                             @"signed" : @"salesman"};
 
     DATAStack *dataStack = [self dataStack];
     User *user = [self userUsingDataStack:dataStack];
@@ -337,6 +335,7 @@
 
     XCTAssertEqualObjects(user.age, @20);
     XCTAssertEqualObjects(user.driverIdentifier, @"123");
+    XCTAssertEqualObjects(user.rawSigned, @"salesman");
 }
 
 - (void)testIgnoredTransformables {

--- a/Tests/Models/Attributes+CoreDataProperties.h
+++ b/Tests/Models/Attributes+CoreDataProperties.h
@@ -4,6 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Attributes (CoreDataProperties)
 
+@property (nullable, nonatomic, retain) NSString *attributeType;
 @property (nullable, nonatomic, retain) NSData *binaryData;
 @property (nullable, nonatomic, retain) NSNumber *boolean;
 @property (nullable, nonatomic, retain) NSDecimalNumber *decimal;

--- a/Tests/Models/Attributes+CoreDataProperties.h
+++ b/Tests/Models/Attributes+CoreDataProperties.h
@@ -4,7 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Attributes (CoreDataProperties)
 
-@property (nullable, nonatomic, retain) NSString *attributeType;
+@property (nullable, nonatomic, retain) NSString *attributesType;
 @property (nullable, nonatomic, retain) NSData *binaryData;
 @property (nullable, nonatomic, retain) NSNumber *boolean;
 @property (nullable, nonatomic, retain) NSDecimalNumber *decimal;

--- a/Tests/Models/Attributes+CoreDataProperties.m
+++ b/Tests/Models/Attributes+CoreDataProperties.m
@@ -2,7 +2,7 @@
 
 @implementation Attributes (CoreDataProperties)
 
-@dynamic attributeType;
+@dynamic attributesType;
 @dynamic binaryData;
 @dynamic boolean;
 @dynamic decimal;

--- a/Tests/Models/Attributes+CoreDataProperties.m
+++ b/Tests/Models/Attributes+CoreDataProperties.m
@@ -2,6 +2,7 @@
 
 @implementation Attributes (CoreDataProperties)
 
+@dynamic attributeType;
 @dynamic binaryData;
 @dynamic boolean;
 @dynamic decimal;

--- a/Tests/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Tests/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -81,6 +81,11 @@
         <attribute name="ignoreTransformable" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="numberOfAttendes" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="rawSigned" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="hyper.remoteKey" value="signed"/>
+            </userInfo>
+        </attribute>
         <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="userDescription" optional="YES" attributeType="String" syncable="YES"/>
@@ -98,6 +103,6 @@
         <element name="Park" positionX="27" positionY="72" width="128" height="75"/>
         <element name="Recursive" positionX="45" positionY="90" width="128" height="90"/>
         <element name="Room" positionX="27" positionY="72" width="128" height="75"/>
-        <element name="User" positionX="9" positionY="54" width="128" height="315"/>
+        <element name="User" positionX="9" positionY="54" width="128" height="330"/>
     </elements>
 </model>

--- a/Tests/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Tests/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15C50" minimumToolsVersion="Xcode 7.0">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Xcode 7.0">
     <entity name="Apartment" representedClassName="Apartment" syncable="YES">
         <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <relationship name="building" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Building" inverseName="apartments" inverseEntity="Building" syncable="YES"/>
         <relationship name="rooms" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Room" inverseName="apartment" inverseEntity="Room" syncable="YES"/>
     </entity>
     <entity name="Attributes" representedClassName="Attributes" syncable="YES">
+        <attribute name="attributeType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="binaryData" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="boolean" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="decimal" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
@@ -89,7 +90,7 @@
     </entity>
     <elements>
         <element name="Apartment" positionX="-18" positionY="27" width="128" height="90"/>
-        <element name="Attributes" positionX="45" positionY="189" width="128" height="255"/>
+        <element name="Attributes" positionX="45" positionY="189" width="128" height="270"/>
         <element name="Building" positionX="0" positionY="45" width="128" height="90"/>
         <element name="Company" positionX="18" positionY="63" width="128" height="90"/>
         <element name="Market" positionX="-45" positionY="0" width="128" height="75"/>

--- a/Tests/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Tests/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -6,7 +6,7 @@
         <relationship name="rooms" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Room" inverseName="apartment" inverseEntity="Room" syncable="YES"/>
     </entity>
     <entity name="Attributes" representedClassName="Attributes" syncable="YES">
-        <attribute name="attributeType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="attributesType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="binaryData" optional="YES" attributeType="Binary" syncable="YES"/>
         <attribute name="boolean" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="decimal" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>

--- a/Tests/Models/Ordered.xcdatamodeld/Ordered.xcdatamodel/contents
+++ b/Tests/Models/Ordered.xcdatamodeld/Ordered.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9525" systemVersion="15C50" minimumToolsVersion="Xcode 7.0">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Xcode 7.0">
     <entity name="Note" representedClassName="Note" syncable="YES">
         <attribute name="destroy" optional="YES" attributeType="Boolean" syncable="YES"/>
         <attribute name="remoteID" optional="YES" attributeType="Integer 32" syncable="YES"/>
@@ -27,6 +27,11 @@
         <attribute name="ignoreTransformable" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="numberOfAttendes" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="rawSigned" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="hyper.remoteKey" value="signed"/>
+            </userInfo>
+        </attribute>
         <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="userDescription" optional="YES" attributeType="String" syncable="YES"/>
@@ -35,6 +40,6 @@
     </entity>
     <elements>
         <element name="Note" positionX="-63" positionY="-18" width="128" height="105"/>
-        <element name="User" positionX="-54" positionY="-9" width="128" height="300"/>
+        <element name="User" positionX="-54" positionY="-9" width="128" height="315"/>
     </elements>
 </model>

--- a/Tests/Models/User+CoreDataProperties.h
+++ b/Tests/Models/User+CoreDataProperties.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface User (CoreDataProperties)
 
+@property (nullable, nonatomic, retain) NSString *rawSigned;
 @property (nullable, nonatomic, retain) NSNumber *age;
 @property (nullable, nonatomic, retain) NSDate *birthDate;
 @property (nullable, nonatomic, retain) NSNumber *contractID;

--- a/Tests/Models/User+CoreDataProperties.m
+++ b/Tests/Models/User+CoreDataProperties.m
@@ -4,6 +4,7 @@
 
 @implementation User (CoreDataProperties)
 
+@dynamic rawSigned;
 @dynamic age;
 @dynamic birthDate;
 @dynamic contractID;


### PR DESCRIPTION
Hard to realize how I haven't realized this one. Mapping to something that could be a reserved attribute fails.

For example mapping: `type` to `attributeType` should work seamlessly for the Attribute model, but fails.
