### PR TITLE
Fix for #86 to add camelCase support.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - DATAStack (4.2.1)
-  - NSManagedObject-HYPPropertyMapper (3.4.2):
+  - NSManagedObject-HYPPropertyMapper (3.4.3):
     - NSString-HYPNetworking (~> 0.4.0)
   - NSString-HYPNetworking (0.4.0)
 
@@ -10,11 +10,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   NSManagedObject-HYPPropertyMapper:
-    :path: "."
+    :path: .
 
 SPEC CHECKSUMS:
   DATAStack: 38009d8509307fca8c5bb26bca149e2e601fc369
-  NSManagedObject-HYPPropertyMapper: 9f3dd46e4265d7f6ba1ce0039ce1fc28524e9937
+  NSManagedObject-HYPPropertyMapper: e75901a91950e9c80510f33bb41e94a2d6ce677c
   NSString-HYPNetworking: 24c3828eebde8a37cc16101a475934a56ac820c0
 
 COCOAPODS: 0.39.0

--- a/Source/NSManagedObject+HYPPropertyMapperHelpers.m
+++ b/Source/NSManagedObject+HYPPropertyMapperHelpers.m
@@ -38,6 +38,11 @@
                 foundAttributeDescription = attributeDescription;
                 *stop = YES;
             }
+            
+            if ([attributeDescription.name isEqualToString:remoteKey]) {
+                foundAttributeDescription = attributeDescription;
+                *stop = YES;
+            }
 
             NSString *localKey = [remoteKey hyp_localString];
             BOOL isReservedKey = ([[NSManagedObject reservedAttributes] containsObject:remoteKey]);

--- a/Tests/HYPFillWithDictionaryTests.m
+++ b/Tests/HYPFillWithDictionaryTests.m
@@ -147,6 +147,49 @@
     XCTAssertNil(attributes.transformable);
 }
 
+- (void)testAllAttributesInCamelCase {
+    NSDictionary *values = @{@"integerString" : @"16",
+                             @"integer16" : @16,
+                             @"integer32" : @32,
+                             @"integer64" : @64,
+                             @"decimalString" : @"12.2",
+                             @"decimal" : @12.2,
+                             @"doubleValueString": @"12.2",
+                             @"doubleValue": @12.2,
+                             @"floatValueString" : @"12.2",
+                             @"floatValue" : @12.2,
+                             @"string" : @"string",
+                             @"boolean" : @YES,
+                             @"binaryData" : @"Data",
+                             @"transformable" : @"Ignore me, too"};
+    
+    DATAStack *dataStack = [self dataStack];
+    Attributes *attributes = [self entityNamed:@"Attributes" inContext:dataStack.mainContext];
+    [attributes hyp_fillWithDictionary:values];
+    
+    XCTAssertEqualObjects(attributes.integerString, @16);
+    XCTAssertEqualObjects(attributes.integer16, @16);
+    XCTAssertEqualObjects(attributes.integer32, @32);
+    XCTAssertEqualObjects(attributes.integer64, @64);
+    
+    XCTAssertEqualObjects(attributes.decimalString, [NSDecimalNumber decimalNumberWithString:@"12.2"]);
+    XCTAssertEqualObjects(NSStringFromClass([attributes.decimalString class]), NSStringFromClass([NSDecimalNumber class]));
+    XCTAssertNotEqualObjects(NSStringFromClass([attributes.decimalString class]), NSStringFromClass([NSNumber class]));
+    
+    XCTAssertEqualObjects(attributes.decimal, [NSDecimalNumber decimalNumberWithString:@"12.2"]);
+    XCTAssertEqualObjects(NSStringFromClass([attributes.decimal class]), NSStringFromClass([NSDecimalNumber class]));
+    XCTAssertNotEqualObjects(NSStringFromClass([attributes.decimal class]), NSStringFromClass([NSNumber class]));
+    
+    XCTAssertEqualObjects(attributes.doubleValueString, @12.2);
+    XCTAssertEqualObjects(attributes.doubleValue, @12.2);
+    XCTAssertEqualWithAccuracy(attributes.floatValueString.longValue, [@12 longValue], 1.0);
+    XCTAssertEqualWithAccuracy(attributes.floatValue.longValue, [@12 longValue], 1.0);
+    XCTAssertEqualObjects(attributes.string, @"string");
+    XCTAssertEqualObjects(attributes.boolean, @YES);
+    XCTAssertEqualObjects(attributes.binaryData, [NSKeyedArchiver archivedDataWithRootObject:@"Data"]);
+    XCTAssertNil(attributes.transformable);
+}
+
 - (void)testFillManagedObjectWithDictionary {
     NSDictionary *values = @{@"first_name" : @"Jane",
                              @"last_name"  : @"Hyperseed"};


### PR DESCRIPTION
Fix for #86 to add camelCase support. Simple change to check if the local and remote names are identical (after checking for a custom remote name). Includes tests.
