### PR TITLE
Transformables support

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		148956E11C5F6AED00CA505D /* Ordered.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 148956DF1C5F6AED00CA505D /* Ordered.xcdatamodeld */; };
 		148956E41C5F6AF500CA505D /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 148956E21C5F6AF500CA505D /* Model.xcdatamodeld */; };
 		14BAEF221C5F5F250023D0CA /* HYPFillWithDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 14BAEF211C5F5F250023D0CA /* HYPFillWithDictionaryTests.m */; };
+		5FC996E91CBE3DAC00AABF9C /* DateStringTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FC996E81CBE3DAC00AABF9C /* DateStringTransformer.m */; };
 		FEF267E8E559DCE44CDA1D89 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A270238462A3030B20904C17 /* Pods.framework */; };
 /* End PBXBuildFile section */
 
@@ -91,6 +92,8 @@
 		14C0AF811BD6D4230009ECBE /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		14C0AF821BD6D4230009ECBE /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		14C0AF831BD6D4230009ECBE /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		5FC996E71CBE3DAC00AABF9C /* DateStringTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DateStringTransformer.h; sourceTree = "<group>"; };
+		5FC996E81CBE3DAC00AABF9C /* DateStringTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DateStringTransformer.m; sourceTree = "<group>"; };
 		A270238462A3030B20904C17 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3F34E9973A0D22911EE3A3B /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		E61B1695DF4EEEBA82FBCFBD /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
@@ -151,6 +154,8 @@
 				1467A3751C06057B0036EC82 /* User+CoreDataProperties.m */,
 				1467A3761C06057B0036EC82 /* User.h */,
 				1467A3771C06057B0036EC82 /* User.m */,
+				5FC996E71CBE3DAC00AABF9C /* DateStringTransformer.h */,
+				5FC996E81CBE3DAC00AABF9C /* DateStringTransformer.m */,
 				148956DF1C5F6AED00CA505D /* Ordered.xcdatamodeld */,
 				148956E21C5F6AF500CA505D /* Model.xcdatamodeld */,
 			);
@@ -369,6 +374,7 @@
 				1467A3881C06057B0036EC82 /* Room.m in Sources */,
 				14260D501BDD5D2100E6A83B /* HYPDictionaryTests.m in Sources */,
 				1467A3791C06057B0036EC82 /* Apartment.m in Sources */,
+				5FC996E91CBE3DAC00AABF9C /* DateStringTransformer.m in Sources */,
 				1467A37B1C06057B0036EC82 /* Building.m in Sources */,
 				148956E11C5F6AED00CA505D /* Ordered.xcdatamodeld in Sources */,
 				1467A3871C06057B0036EC82 /* Room+CoreDataProperties.m in Sources */,

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - DATAStack (4.2.1)
+  - DATAStack (4.2.2)
   - NSManagedObject-HYPPropertyMapper (3.5.0):
     - NSString-HYPNetworking (~> 0.4.0)
   - NSString-HYPNetworking (0.4.0)
@@ -10,10 +10,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   NSManagedObject-HYPPropertyMapper:
-    :path: .
+    :path: "."
 
 SPEC CHECKSUMS:
-  DATAStack: 38009d8509307fca8c5bb26bca149e2e601fc369
+  DATAStack: f38df2e6deaf9d2eed15a0a68ba6c4c76e657f8a
   NSManagedObject-HYPPropertyMapper: c307b6455b8fd572f793e4a80b9055f3c2fc0e3b
   NSString-HYPNetworking: 24c3828eebde8a37cc16101a475934a56ac820c0
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - DATAStack (4.2.1)
-  - NSManagedObject-HYPPropertyMapper (3.4.3):
+  - NSManagedObject-HYPPropertyMapper (3.5.0):
     - NSString-HYPNetworking (~> 0.4.0)
   - NSString-HYPNetworking (0.4.0)
 
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   DATAStack: 38009d8509307fca8c5bb26bca149e2e601fc369
-  NSManagedObject-HYPPropertyMapper: e75901a91950e9c80510f33bb41e94a2d6ce677c
+  NSManagedObject-HYPPropertyMapper: c307b6455b8fd572f793e4a80b9055f3c2fc0e3b
   NSString-HYPNetworking: 24c3828eebde8a37cc16101a475934a56ac820c0
 
 COCOAPODS: 0.39.0

--- a/Source/NSManagedObject+HYPPropertyMapperHelpers.m
+++ b/Source/NSManagedObject+HYPPropertyMapperHelpers.m
@@ -142,6 +142,8 @@
     BOOL stringValueAndDecimalAttribute = ([remoteValue isKindOfClass:[NSString class]] &&
                                            attributedClass == [NSDecimalNumber class]);
 
+    BOOL transformableAttribute         = (!attributedClass && [attributeDescription valueTransformerName] && value == nil);
+
     if (stringValueAndNumberAttribute) {
         NSNumberFormatter *formatter = [NSNumberFormatter new];
         formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
@@ -159,14 +161,9 @@
         value = [NSDecimalNumber decimalNumberWithDecimal:[number decimalValue]];
     } else if (stringValueAndDecimalAttribute) {
         value = [NSDecimalNumber decimalNumberWithString:remoteValue];
-    }
-    
-    // If it's a transformable value - there will be no class name, but transformer name will be present. Value will be nil at this point
-    if (!attributedClass && [attributeDescription valueTransformerName] && value == nil) {
-        // get a registered transformer for specified name
+    } else if (transformableAttribute) {
         NSValueTransformer *transformer = [NSValueTransformer valueTransformerForName:[attributeDescription valueTransformerName]];
         if (transformer) {
-            // get new value from transformer
             id newValue = [transformer transformedValue:remoteValue];
             if (newValue) {
                 value = newValue;

--- a/Source/NSManagedObject+HYPPropertyMapperHelpers.m
+++ b/Source/NSManagedObject+HYPPropertyMapperHelpers.m
@@ -122,19 +122,19 @@
         value = remoteValue;
     }
 
-    BOOL stringValueAndNumberAttribute = ([remoteValue isKindOfClass:[NSString class]] &&
+    BOOL stringValueAndNumberAttribute  = ([remoteValue isKindOfClass:[NSString class]] &&
                                           attributedClass == [NSNumber class]);
 
-    BOOL numberValueAndStringAttribute = ([remoteValue isKindOfClass:[NSNumber class]] &&
+    BOOL numberValueAndStringAttribute  = ([remoteValue isKindOfClass:[NSNumber class]] &&
                                           attributedClass == [NSString class]);
 
-    BOOL stringValueAndDateAttribute   = ([remoteValue isKindOfClass:[NSString class]] &&
+    BOOL stringValueAndDateAttribute    = ([remoteValue isKindOfClass:[NSString class]] &&
                                           attributedClass == [NSDate class]);
 
-    BOOL numberValueAndDateAttribute   = ([remoteValue isKindOfClass:[NSNumber class]] &&
+    BOOL numberValueAndDateAttribute    = ([remoteValue isKindOfClass:[NSNumber class]] &&
                                           attributedClass == [NSDate class]);
 
-    BOOL dataAttribute                 = (attributedClass == [NSData class]);
+    BOOL dataAttribute                  = (attributedClass == [NSData class]);
 
     BOOL numberValueAndDecimalAttribute = ([remoteValue isKindOfClass:[NSNumber class]] &&
                                            attributedClass == [NSDecimalNumber class]);

--- a/Source/NSManagedObject+HYPPropertyMapperHelpers.m
+++ b/Source/NSManagedObject+HYPPropertyMapperHelpers.m
@@ -160,6 +160,19 @@
     } else if (stringValueAndDecimalAttribute) {
         value = [NSDecimalNumber decimalNumberWithString:remoteValue];
     }
+    
+    // If it's a transformable value - there will be no class name, but transformer name will be present. Value will be nil at this point
+    if (!attributedClass && [attributeDescription valueTransformerName] && value == nil) {
+        // get a registered transformer for specified name
+        NSValueTransformer *transformer = [NSValueTransformer valueTransformerForName:[attributeDescription valueTransformerName]];
+        if (transformer) {
+            // get new value from transformer
+            id newValue = [transformer transformedValue:remoteValue];
+            if (newValue) {
+                value = newValue;
+            }
+        }
+    }
 
     return value;
 }

--- a/Tests/HYPFillWithDictionaryTests.m
+++ b/Tests/HYPFillWithDictionaryTests.m
@@ -391,6 +391,18 @@
     XCTAssertNil(user.ignoreTransformable);
 }
 
+- (void)testRegisteredTransformables {
+    NSDictionary *values = @{@"registeredTransformable" : @"/Date(1460537233000)/"};
+   
+    DATAStack *dataStack = [self dataStack];
+    User *user = [self userUsingDataStack:dataStack];
+    [user hyp_fillWithDictionary:values];
+
+    XCTAssertNotNil(user.registeredTransformable);
+    XCTAssertTrue([user.registeredTransformable isKindOfClass:[NSDate class]]);
+}
+
+
 - (void)testCustomKey {
     DATAStack *dataStack = [self dataStack];
 

--- a/Tests/HYPFillWithDictionaryTests.m
+++ b/Tests/HYPFillWithDictionaryTests.m
@@ -392,16 +392,20 @@
 }
 
 - (void)testRegisteredTransformables {
-    NSDictionary *values = @{@"registeredTransformable" : @"/Date(1460537233000)/"};
+    NSDictionary *values = @{@"registeredTransformable" : @"/Date(1451606400000)/"};
    
     DATAStack *dataStack = [self dataStack];
     User *user = [self userUsingDataStack:dataStack];
     [user hyp_fillWithDictionary:values];
 
+    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+    dateFormat.dateFormat = @"yyyy-MM-dd";
+    dateFormat.timeZone = [NSTimeZone timeZoneWithName:@"GMT"];
+    NSDate *date = [dateFormat dateFromString:@"2016-01-01"];
     XCTAssertNotNil(user.registeredTransformable);
+    XCTAssertEqualObjects(user.registeredTransformable, date);
     XCTAssertTrue([user.registeredTransformable isKindOfClass:[NSDate class]]);
 }
-
 
 - (void)testCustomKey {
     DATAStack *dataStack = [self dataStack];

--- a/Tests/HelperTests.m
+++ b/Tests/HelperTests.m
@@ -36,7 +36,7 @@
     XCTAssertEqualObjects(attributeDescription.name, @"name");
 
     attributeDescription = [company attributeDescriptionForRemoteKey:@"id"];
-    XCTAssertEqualObjects(attributeDescription.name, @"remoteID");
+    XCTAssertEqualObjects(attributeDescription.name, @"b");
 }
 
 - (void)testAttributeDescriptionForKeyB {

--- a/Tests/HelperTests.m
+++ b/Tests/HelperTests.m
@@ -36,7 +36,7 @@
     XCTAssertEqualObjects(attributeDescription.name, @"name");
 
     attributeDescription = [company attributeDescriptionForRemoteKey:@"id"];
-    XCTAssertEqualObjects(attributeDescription.name, @"b");
+    XCTAssertEqualObjects(attributeDescription.name, @"remoteID");
 }
 
 - (void)testAttributeDescriptionForKeyB {

--- a/Tests/Models/DateStringTransformer.h
+++ b/Tests/Models/DateStringTransformer.h
@@ -1,15 +1,6 @@
-//
-//  DateStringTransformer.h
-//  Demo
-//
-//  Created by Aleksandr Kelbas on 13/04/2016.
-//
-//
+@import Foundation;
 
-#import <Foundation/Foundation.h>
-
-
-/*
+/**
  This class is transforming "/Date(1460537233000)/" string into an NSDate object that can be stored in Core Data
  */
 @interface DateStringTransformer : NSValueTransformer

--- a/Tests/Models/DateStringTransformer.h
+++ b/Tests/Models/DateStringTransformer.h
@@ -1,5 +1,5 @@
 //
-//  BoolStringTransformer.h
+//  DateStringTransformer.h
 //  Demo
 //
 //  Created by Aleksandr Kelbas on 13/04/2016.
@@ -10,7 +10,7 @@
 
 
 /*
- This class is transforming "YES" or "NO" string into an NSNumber `withBool:` that can be stored in Core Data
+ This class is transforming "/Date(1460537233000)/" string into an NSDate object that can be stored in Core Data
  */
 @interface DateStringTransformer : NSValueTransformer
 

--- a/Tests/Models/DateStringTransformer.h
+++ b/Tests/Models/DateStringTransformer.h
@@ -1,0 +1,17 @@
+//
+//  BoolStringTransformer.h
+//  Demo
+//
+//  Created by Aleksandr Kelbas on 13/04/2016.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+
+/*
+ This class is transforming "YES" or "NO" string into an NSNumber `withBool:` that can be stored in Core Data
+ */
+@interface DateStringTransformer : NSValueTransformer
+
+@end

--- a/Tests/Models/DateStringTransformer.m
+++ b/Tests/Models/DateStringTransformer.m
@@ -1,0 +1,37 @@
+//
+//  BoolStringTransformer.m
+//  Demo
+//
+//  Created by Aleksandr Kelbas on 13/04/2016.
+//
+//
+
+#import "DateStringTransformer.h"
+
+@implementation DateStringTransformer
+
++ (Class) transformedValueClass {
+    return [NSDate class];
+}
+
++ (BOOL)allowsReverseTransformation {
+    return NO;
+}
+
+- (nullable id)transformedValue:(nullable id)value {
+    if ([value isKindOfClass:[NSString class]]) {
+        // in this example string should be of "/Date(1460537233000)/" format
+        NSString * intStr = [[(NSString*)value stringByReplacingOccurrencesOfString:@"/Date(" withString:@""] stringByReplacingOccurrencesOfString:@")/" withString:@""];
+        NSInteger timestampMS = [intStr integerValue];
+        float timestamp = timestampMS / 1000.0;
+        NSDate * date = [[NSDate alloc] initWithTimeIntervalSince1970:timestamp];
+        
+        return date;
+        
+    } else {
+        // Return original value
+        return value;
+    }
+}
+
+@end

--- a/Tests/Models/DateStringTransformer.m
+++ b/Tests/Models/DateStringTransformer.m
@@ -1,5 +1,5 @@
 //
-//  BoolStringTransformer.m
+//  DateStringTransformer.m
 //  Demo
 //
 //  Created by Aleksandr Kelbas on 13/04/2016.

--- a/Tests/Models/DateStringTransformer.m
+++ b/Tests/Models/DateStringTransformer.m
@@ -1,11 +1,3 @@
-//
-//  DateStringTransformer.m
-//  Demo
-//
-//  Created by Aleksandr Kelbas on 13/04/2016.
-//
-//
-
 #import "DateStringTransformer.h"
 
 @implementation DateStringTransformer
@@ -21,15 +13,12 @@
 - (nullable id)transformedValue:(nullable id)value {
     if ([value isKindOfClass:[NSString class]]) {
         // in this example string should be of "/Date(1460537233000)/" format
-        NSString * intStr = [[(NSString*)value stringByReplacingOccurrencesOfString:@"/Date(" withString:@""] stringByReplacingOccurrencesOfString:@")/" withString:@""];
+        NSString *intStr = [[(NSString*)value stringByReplacingOccurrencesOfString:@"/Date(" withString:@""] stringByReplacingOccurrencesOfString:@")/" withString:@""];
         NSInteger timestampMS = [intStr integerValue];
         float timestamp = timestampMS / 1000.0;
-        NSDate * date = [[NSDate alloc] initWithTimeIntervalSince1970:timestamp];
-        
+        NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:timestamp];
         return date;
-        
     } else {
-        // Return original value
         return value;
     }
 }

--- a/Tests/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Tests/Models/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -86,6 +86,7 @@
                 <entry key="hyper.remoteKey" value="signed"/>
             </userInfo>
         </attribute>
+        <attribute name="registeredTransformable" optional="YES" attributeType="Transformable" valueTransformerName="DateStringTransformer" syncable="YES"/>
         <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="userDescription" optional="YES" attributeType="String" syncable="YES"/>
@@ -103,6 +104,6 @@
         <element name="Park" positionX="27" positionY="72" width="128" height="75"/>
         <element name="Recursive" positionX="45" positionY="90" width="128" height="90"/>
         <element name="Room" positionX="27" positionY="72" width="128" height="75"/>
-        <element name="User" positionX="9" positionY="54" width="128" height="330"/>
+        <element name="User" positionX="9" positionY="54" width="128" height="345"/>
     </elements>
 </model>

--- a/Tests/Models/Ordered.xcdatamodeld/Ordered.xcdatamodel/contents
+++ b/Tests/Models/Ordered.xcdatamodeld/Ordered.xcdatamodel/contents
@@ -32,6 +32,7 @@
                 <entry key="hyper.remoteKey" value="signed"/>
             </userInfo>
         </attribute>
+        <attribute name="registeredTransformable" optional="YES" attributeType="Transformable" valueTransformerName="DateStringTransformer" syncable="YES"/>
         <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <attribute name="userDescription" optional="YES" attributeType="String" syncable="YES"/>
@@ -40,6 +41,6 @@
     </entity>
     <elements>
         <element name="Note" positionX="-63" positionY="-18" width="128" height="105"/>
-        <element name="User" positionX="-54" positionY="-9" width="128" height="315"/>
+        <element name="User" positionX="-54" positionY="-9" width="128" height="330"/>
     </elements>
 </model>

--- a/Tests/Models/User+CoreDataProperties.h
+++ b/Tests/Models/User+CoreDataProperties.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, retain) NSData *hobbies;
 @property (nullable, nonatomic, retain) NSString *ignoredParameter;
 @property (nullable, nonatomic, retain) id ignoreTransformable;
+@property (nullable, nonatomic, retain) id registeredTransformable;
 @property (nullable, nonatomic, retain) NSString *lastName;
 @property (nullable, nonatomic, retain) NSNumber *numberOfAttendes;
 @property (nullable, nonatomic, retain) NSNumber *remoteID;

--- a/Tests/Models/User+CoreDataProperties.m
+++ b/Tests/Models/User+CoreDataProperties.m
@@ -15,6 +15,7 @@
 @dynamic hobbies;
 @dynamic ignoredParameter;
 @dynamic ignoreTransformable;
+@dynamic registeredTransformable;
 @dynamic lastName;
 @dynamic numberOfAttendes;
 @dynamic remoteID;


### PR DESCRIPTION
Every once in a while a shitty API comes along :) I've been unfortunate to work with one recently...

I've had an issue with their date object... they've been storing them as strings: 
`"\Date(_timestamp_in_milliseconds_here_)\"`
I've been using `Sync` for this project and have been struggling with these dates as I need to be able to do a proper search in my Core Data by date, etc... So, what I figured out could be a solution is to support NSValueTransformers.

In this small PR I've got it working. Anyone who want to transform value before it going to the database needs to implement `NSValueTransformer` subclass and specify it in their core data model.

If OS for some reason fails to identify and auto-register your transformer, you can do this manually by using `setValueTransformer: forName:` class function of `NSValueTransfomer`.
