### PR TITLE
Get default values from NSEntityDescription+SYNCPrimaryKey

### DIFF
--- a/NSManagedObject-HYPPropertyMapper.podspec
+++ b/NSManagedObject-HYPPropertyMapper.podspec
@@ -24,4 +24,5 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
   s.requires_arc = true
   s.dependency 'NSString-HYPNetworking', '~> 0.4.0'
+  s.dependency 'NSEntityDescription-SYNCPrimaryKey', '~> 1.0.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,9 @@
 PODS:
   - DATAStack (5.0.0)
-  - NSManagedObject-HYPPropertyMapper (3.6.0):
+  - NSEntityDescription-SYNCPrimaryKey (1.0.0):
+    - NSString-HYPNetworking (~> 0.4.0)
+  - NSManagedObject-HYPPropertyMapper (3.6.2):
+    - NSEntityDescription-SYNCPrimaryKey (~> 1.0.0)
     - NSString-HYPNetworking (~> 0.4.0)
   - NSString-HYPNetworking (0.4.0)
 
@@ -10,11 +13,12 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   NSManagedObject-HYPPropertyMapper:
-    :path: .
+    :path: "."
 
 SPEC CHECKSUMS:
   DATAStack: e0111e1db6044c8b355e68311e002cbec8963b28
-  NSManagedObject-HYPPropertyMapper: dbcaa74a43b522d45dacf1ad1c56b41ef008a0c0
+  NSEntityDescription-SYNCPrimaryKey: 3c6c6a49964a6a2e11e42709bd92e2f02b19fe79
+  NSManagedObject-HYPPropertyMapper: 6a5602c1a50d12074d74524414ad3053012895db
   NSString-HYPNetworking: 24c3828eebde8a37cc16101a475934a56ac820c0
 
 COCOAPODS: 0.39.0

--- a/Source/NSManagedObject+HYPPropertyMapperHelpers.h
+++ b/Source/NSManagedObject+HYPPropertyMapperHelpers.h
@@ -2,8 +2,6 @@
 
 #import "NSManagedObject+HYPPropertyMapper.h"
 
-static NSString * const HYPPropertyMapperDefaultRemoteValue = @"id";
-static NSString * const HYPPropertyMapperDefaultLocalValue = @"remoteID";
 static NSString * const HYPPropertyMapperDestroyKey = @"destroy";
 
 @interface NSManagedObject (HYPPropertyMapperHelpers)

--- a/Source/NSManagedObject+HYPPropertyMapperHelpers.m
+++ b/Source/NSManagedObject+HYPPropertyMapperHelpers.m
@@ -3,6 +3,7 @@
 #import "NSManagedObject+HYPPropertyMapper.h"
 #import "NSString+HYPNetworking.h"
 #import "NSDate+HYPPropertyMapper.h"
+#import "NSEntityDescription+SYNCPrimaryKey.h"
 
 @implementation NSManagedObject (HYPPropertyMapperHelpers)
 
@@ -63,8 +64,8 @@
             if ([propertyDescription isKindOfClass:[NSAttributeDescription class]]) {
                 NSAttributeDescription *attributeDescription = (NSAttributeDescription *)propertyDescription;
 
-                if ([remoteKey isEqualToString:HYPPropertyMapperDefaultRemoteValue] &&
-                    [attributeDescription.name isEqualToString:HYPPropertyMapperDefaultLocalValue]) {
+                if ([remoteKey isEqualToString:SYNCDefaultRemotePrimaryKey] &&
+                    ([attributeDescription.name isEqualToString:SYNCDefaultLocalPrimaryKey] || [attributeDescription.name isEqualToString:SYNCDefaultLocalCompatiblePrimaryKey])) {
                     foundAttributeDescription = self.entity.propertiesByName[attributeDescription.name];
                 }
 
@@ -90,8 +91,8 @@
     NSString *customRemoteKey = userInfo[HYPPropertyMapperCustomRemoteKey];
     if (customRemoteKey) {
         remoteKey = customRemoteKey;
-    } else if ([localKey isEqualToString:HYPPropertyMapperDefaultLocalValue]) {
-        remoteKey = HYPPropertyMapperDefaultRemoteValue;
+    } else if ([localKey isEqualToString:SYNCDefaultLocalPrimaryKey] || [localKey isEqualToString:SYNCDefaultLocalCompatiblePrimaryKey]) {
+        remoteKey = SYNCDefaultRemotePrimaryKey;
     } else if ([localKey isEqualToString:HYPPropertyMapperDestroyKey] &&
                relationshipType == HYPPropertyMapperRelationshipTypeNested) {
         remoteKey = [NSString stringWithFormat:@"_%@", HYPPropertyMapperDestroyKey];


### PR DESCRIPTION
`NSManagedObject-HYPPropertyMapper` had it's own variables for default local primary key and remote primary key. 😱 

Updated to make it use: https://github.com/hyperoslo/NSEntityDescription-SYNCPrimaryKey/blob/f2edfcf2f48a4d3f21b5f395889be3b7fbd69f26/Source/NSEntityDescription%2BSYNCPrimaryKey.h#L3-L8

At the same time it adds support for making JSON representations that use `id` besides `remoteID`.
