### PR TITLE
Ignore properties with hyper.nonExportable

### DIFF
--- a/Sources/SYNCPropertyMapper/NSManagedObject+SYNCPropertyMapper.m
+++ b/Sources/SYNCPropertyMapper/NSManagedObject+SYNCPropertyMapper.m
@@ -77,13 +77,18 @@ static NSString * const SYNCPropertyMapperNestedAttributesKey = @"attributes";
 
     for (id propertyDescription in self.entity.properties) {
         if ([propertyDescription isKindOfClass:[NSAttributeDescription class]]) {
-            id value = [self valueForAttributeDescription:propertyDescription
-                                            dateFormatter:dateFormatter
-                                         relationshipType:relationshipType];
-            if (value) {
-                NSString *remoteKey = [self remoteKeyForAttributeDescription:propertyDescription
-                                                       usingRelationshipType:relationshipType];
-                managedObjectAttributes[remoteKey] = value;
+            NSPropertyDescription *description = (NSRelationshipDescription *)propertyDescription;
+            NSDictionary *userInfo = description.userInfo;
+            NSString *nonExportableKey = userInfo[SYNCPropertyMapperNonExportableKey];
+            if (nonExportableKey == nil) {
+                id value = [self valueForAttributeDescription:propertyDescription
+                                                dateFormatter:dateFormatter
+                                             relationshipType:relationshipType];
+                if (value) {
+                    NSString *remoteKey = [self remoteKeyForAttributeDescription:propertyDescription
+                                                           usingRelationshipType:relationshipType];
+                    managedObjectAttributes[remoteKey] = value;
+                }
             }
         } else if ([propertyDescription isKindOfClass:[NSRelationshipDescription class]] &&
                    relationshipType != SYNCPropertyMapperRelationshipTypeNone) {

--- a/Tests/SYNCPropertyMapper/FillWithDictionaryTests.swift
+++ b/Tests/SYNCPropertyMapper/FillWithDictionaryTests.swift
@@ -3,11 +3,13 @@ import XCTest
 import DATAStack
 
 class FillWithDictionaryTests: XCTestCase {
+    
     func testBug112() {
         let dataStack = Helper.dataStackWithModelName("Bug112")
-
+        
         let owner = Helper.insertEntity("Owner", dataStack: dataStack)
         owner.setValue(1, forKey: "id")
+        owner.setValue("Maria", forKey: "name")
 
         let taskList = Helper.insertEntity("TaskList", dataStack: dataStack)
         taskList.setValue(1, forKey: "id")
@@ -20,7 +22,9 @@ class FillWithDictionaryTests: XCTestCase {
 
         try! dataStack.mainContext.save()
 
-        let ownerBody = ["id" : 1]
+        let ownerBody = [
+            "id" : 1
+        ] as [String : Any]
         let taskBoby = [
             "id" : 1,
             "owner" : ownerBody
@@ -32,13 +36,13 @@ class FillWithDictionaryTests: XCTestCase {
         ] as [String : Any]
 
         XCTAssertEqual(expected as NSDictionary, taskList.hyp_dictionary(using: .array) as NSDictionary)
-
+        
         try! dataStack.drop()
     }
 
     func testBug121() {
         let dataStack = Helper.dataStackWithModelName("121")
-
+        
         let album = Helper.insertEntity("Album", dataStack: dataStack) as! Album
         let json = [
             "id": "a",
@@ -47,7 +51,24 @@ class FillWithDictionaryTests: XCTestCase {
         album.hyp_fill(with: json)
 
         XCTAssertNotNil(album.coverPhoto)
-
+        
         try! dataStack.drop()
     }
+    
+    func testBug123() {
+        let dataStack = Helper.dataStackWithModelName("Bug112")
+        let owner = Helper.insertEntity("Owner", dataStack: dataStack)
+        owner.setValue(1, forKey: "id")
+        owner.setValue("Ignore me", forKey: "name")
+        
+        try! dataStack.mainContext.save()
+        let expected = [
+            "id" : 1
+            ] as [String : Any]
+        
+        XCTAssertEqual(expected as NSDictionary, owner.hyp_dictionary(using: .none) as NSDictionary)
+        
+        try! dataStack.drop()
+    }
+    
 }

--- a/Tests/SYNCPropertyMapper/Models/Bug112.xcdatamodeld/hypbug.xcdatamodel/contents
+++ b/Tests/SYNCPropertyMapper/Models/Bug112.xcdatamodeld/hypbug.xcdatamodel/contents
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11232" systemVersion="16A323" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11232" systemVersion="15G1004" minimumToolsVersion="Automatic" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="Owner" representedClassName="Owner" syncable="YES" codeGenerationType="class">
         <attribute name="id" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES">
+            <userInfo>
+                <entry key="hyper.nonExportable" value="value"/>
+            </userInfo>
+        </attribute>
         <relationship name="task" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Task" inverseName="owner" inverseEntity="Task" syncable="YES">
             <userInfo>
                 <entry key="hyper.nonExportable" value="true"/>
@@ -24,7 +29,7 @@
         <relationship name="tasks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Task" inverseName="taskList" inverseEntity="Task" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Owner" positionX="-54" positionY="-54" width="128" height="90"/>
+        <element name="Owner" positionX="-54" positionY="-54" width="128" height="105"/>
         <element name="Task" positionX="169" positionY="84" width="128" height="90"/>
         <element name="TaskList" positionX="-245" positionY="99" width="128" height="90"/>
     </elements>


### PR DESCRIPTION
Modifications to also ignore properties with hyper.nonExportable.
Currently ignoring only relationships
